### PR TITLE
Bumped version for top-bottom split support.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aframe-stereo-component",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Stereoscopic component for A-Frame VR.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Top-Bottom support was added with https://github.com/oscarmarinmiro/aframe-stereo-component/pull/10. Bumping the version should also have a subsequent `npm publish` to https://www.npmjs.com/package/aframe-stereo-component.
