### PR TITLE
modified checks for string selector to allow for a-assets translation…

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,13 +26,23 @@ module.exports = {
           if(this.el.getAttribute("material")!==null && 'src' in this.el.getAttribute("material") && this.el.getAttribute("material").src !== "") {
             var src = this.el.getAttribute("material").src;
             // If src is a string, treat it like a selector, for aframe <= v0.3
-            if ((toString.call(src) == '[object String]'
-                 && document.querySelector(src) !== null
-                 && document.querySelector(src).tagName === "VIDEO")
-                ||
-                // If src is a video element , just get the tagName
-                ('tagName' in src
-                 && src.tagName === "VIDEO")) {
+            if (toString.call(src) == '[object String]') {
+              var validSelector = true;
+              // try/catch to validate selector as we might have a string that is actually the
+              // asset path replaced by the a-assets system IE <a-entity material="src:#imgID">
+              // may get translated to "/assets/image.jpg"
+              try {
+                document.querySelector(str);
+              } catch(e) {
+                validSelector = false;
+              }
+            }
+
+            if (validSelector && (document.querySelector(src).tagName === "VIDEO"
+              ||
+              // If src is a video element , just get the tagName
+              'tagName' in src
+               && src.tagName === "VIDEO")) {
               this.material_is_a_video = true;
             }
           }


### PR DESCRIPTION
Fixes an issue where a-assets images' selectors were being translated to the full asset path by the time the stereo component was checking to see if the item was a video. 

Fix essentially just checks that the string is a valid selector before attempting to use document.querySelector() on it while checking if it's a video tag.